### PR TITLE
update docker binary used

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,14 +82,10 @@ docker/autoconf-2.69.tar.gz:
   size: 1927468
   object_id: 83391b7e-d4bf-4052-92bb-e708f33e25c6
   sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
-docker/docker-18.09.2.tgz:
-  size: 48020699
-  object_id: c9a25eb3-2d23-457f-714d-0c370916a687
-  sha: sha256:183e10448f0c3a0dc82c9d504c5280c29527b89af0fc71cb27115d684b26c8bd
-docker/docker-19.03.3.tgz:
-  size: 63244685
-  object_id: 709b25a0-a988-48c5-4963-f831926d8030
-  sha: sha256:c3c8833e227b61fe6ce0bc5c17f97fa547035bef4ef17cf6601f30b0f20f4ce5
+docker/moby-20.10.23.tar.gz:
+  size: 71882609
+  object_id: e26e53a4-9c2f-4fc8-6485-bb1c77ff007b
+  sha: sha256:a19e82ca172183f856d2eadcb03a8f16455ca13675594c31f1a9a49a5e38d9aa
 docker/swarm-1.2.9.zip:
   size: 2151106
   object_id: 64eda587-2fd4-43d8-6a2b-760c7986ebb9

--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -9,7 +9,7 @@ CPUS=`grep -c ^processor /proc/cpuinfo`
 # We grab the latest versions that are in the directory
 AUFS_TOOLS_VERSION=`ls -r docker/aufs-tools_*.deb | sed 's/docker\/aufs-tools_\(.*\).deb/\1/' | head -1`
 AUTOCONF_VERSION=`ls -r docker/autoconf-*.tar.gz | sed 's/docker\/autoconf-\(.*\)\.tar\.gz/\1/' | head -1`
-DOCKER_VERSION=`ls -r docker/docker-*.tgz | sed 's/docker\/docker-\(.*\)\.tgz/\1/' | head -1`
+DOCKER_VERSION=`ls -r docker/moby-*.tar.gz | sed 's/docker\/moby-\(.*\)\.tar\.gz/\1/' | head -1`
 
 # Extract Autoconf package
 echo "Extracting Autoconf ${AUTOCONF_VERSION}..."
@@ -28,7 +28,7 @@ make install
 
 # Extract docker package
 echo "Extracting docker ${DOCKER_VERSION}..."
-tar xzvf ${BOSH_COMPILE_TARGET}/docker/docker-${DOCKER_VERSION}.tgz
+tar xzvf ${BOSH_COMPILE_TARGET}/docker/moby-${DOCKER_VERSION}.tar.gz
 if [[ $? != 0 ]] ; then
   echo "Failed extracting docker ${DOCKER_VERSION}"
   exit 1
@@ -37,7 +37,7 @@ fi
 # Copy docker binaries
 echo "Copying docker ${DOCKER_VERSION} binaries..."
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-cp docker/* ${BOSH_INSTALL_TARGET}/bin
+cp binary-daemon/* ${BOSH_INSTALL_TARGET}/bin
 chmod +x ${BOSH_INSTALL_TARGET}/bin/*
 
 # Install aufs-tool deb package

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -4,4 +4,4 @@ dependencies: []
 files:
   - docker/aufs-tools_20120411-3_amd64.deb
   - docker/autoconf-2.69.tar.gz
-  - docker/docker-19.03.3.tgz
+  - docker/moby-20.10.23.tar.gz


### PR DESCRIPTION
Updating docker binary used in service-fabrik-boshrelease. 
We are having issue with docker container creation using old docker binary on jammy stemcell version 1.93